### PR TITLE
feat: enforce page access based on auth role

### DIFF
--- a/src/app/(app)/admin/categories/new/page.tsx
+++ b/src/app/(app)/admin/categories/new/page.tsx
@@ -16,7 +16,7 @@ export default function NewCategoryPage() {
   const { auth } = useAuth();
   
   // Apply admin role guard
-  useAdminRoleGuard('admin');
+  useAdminRoleGuard();
   
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string>("");

--- a/src/app/(app)/admin/new/page.tsx
+++ b/src/app/(app)/admin/new/page.tsx
@@ -10,12 +10,14 @@ import useAuth from "@/hooks/useAuth";
 import validateCreateAdminForm, { AdminFormData } from "@/utils/api/admin/validateCreateAdminForm";
 import createAdminService from "@/services/admin/createAdminService";
 import { Eye, EyeOff, Lock } from "lucide-react";
+import useAdminRoleGuard from "@/hooks/useAdminRoleGuard";
 
 export default function NewAdminPage() {
   const router = useRouter();
   const { auth } = useAuth();
-  const isSuperAdmin = true; // Temporarily set to true for testing
   
+  useAdminRoleGuard();
+
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string>("");
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -29,20 +31,9 @@ export default function NewAdminPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
-  useEffect(() => {
-    // Redirect non-super-admin users to the home page
-    if (!auth.loading && !isSuperAdmin) {
-      router.replace("/");
-    }
-  }, [auth.loading, isSuperAdmin, router]);
 
   if (auth.loading) {
     return <LoadingSpinner size="lg" color="primary" fullScreen={true} />;
-  }
-
-  // If not a super admin, don't render the form
-  if (!isSuperAdmin) {
-    return null;
   }
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/src/app/(app)/admin/students/page.tsx
+++ b/src/app/(app)/admin/students/page.tsx
@@ -1,8 +1,12 @@
 'use client';
 
 import StudentsListing from "@/components/StudentsListing";
+import useAdminRoleGuard from "@/hooks/useAdminRoleGuard";
 
 export default function AdminStudentsPage() {
+
+	useAdminRoleGuard();
+
 	const handleApprove = (id: string) => {
 		console.log(`Approved student with ID: ${id}`);
 	};

--- a/src/app/(app)/admins/page.tsx
+++ b/src/app/(app)/admins/page.tsx
@@ -4,9 +4,8 @@ import AdminsListing from "@/components/AdminsListing";
 import useSuperAdminRoleGuard from "@/hooks/useSuperAdminRoleGuard";
 
 export default function AdminAdminsPage() {
-  const userRole = "super_admin"; // for testing purposes
 
-  useSuperAdminRoleGuard(userRole);
+  useSuperAdminRoleGuard();
 
   return (
     <AdminsListing />

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -24,6 +24,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         });
         setAuth({
           accessToken: response.data.accessToken,
+          user: response.data.user,
           loading: false
         });
       } catch (error) {

--- a/src/hooks/useAdminRoleGuard.ts
+++ b/src/hooks/useAdminRoleGuard.ts
@@ -3,10 +3,12 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import useAuthRedirect from "./UseAuthRedirect";
+import useAuth from "./useAuth";
 
-const useAdminRoleGuard = (userRole?: string): void => {
+const useAdminRoleGuard = (): void => {
   const router = useRouter();
   const [isMounted, setIsMounted] = useState(false);
+  const { auth } = useAuth();
 
   // If user is not authenticated, redirect to login page
   useAuthRedirect();
@@ -17,14 +19,11 @@ const useAdminRoleGuard = (userRole?: string): void => {
 
   useEffect(() => {
     if (isMounted) {
-      const isAdmin = userRole === "admin";
-      const isSuperAdmin = userRole === "super_admin";
-
-      if (!isAdmin && !isSuperAdmin) {
-        router.replace("/");
+      if (!auth.user || !['ADMIN', 'SUPER_ADMIN'].includes(auth?.user?.role)) {
+        router.replace("/"); 
       }
     }
-  }, [userRole, router, isMounted]);
+  }, [router, isMounted]);
 };
 
 export default useAdminRoleGuard;

--- a/src/hooks/useRefreshToken.ts
+++ b/src/hooks/useRefreshToken.ts
@@ -9,14 +9,16 @@ const useRefreshToken = () => {
   const refresh = async () => {
     try {
       const response = await axios.post('/auth/refresh');
-      setAuth(prev => ({
-        ...prev,
-        accessToken: response.data.accessToken
-      }));
+      setAuth({
+        accessToken: response.data.accessToken,
+        user: response.data.user,
+        loading: false,
+      });
       return response.data.accessToken;
     } catch (error) {
       setAuth({
         accessToken: undefined,
+        user: undefined,
         loading: false,
       });
       throw error;

--- a/src/hooks/useSuperAdminRoleGuard.ts
+++ b/src/hooks/useSuperAdminRoleGuard.ts
@@ -3,10 +3,12 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import useAuthRedirect from "./UseAuthRedirect";
+import useAuth from "./useAuth";
 
-const useSuperAdminRoleGuard = (userRole?: string): void => {
+const useSuperAdminRoleGuard = (): void => {
   const router = useRouter();
   const [isMounted, setIsMounted] = useState(false);
+  const { auth } = useAuth();
 
   // If user is not authenticated, redirect to login page
   useAuthRedirect();
@@ -17,13 +19,11 @@ const useSuperAdminRoleGuard = (userRole?: string): void => {
 
   useEffect(() => {
     if (isMounted) {
-      const isSuperAdmin = userRole === "super_admin";
-      
-      if (!isSuperAdmin) {
-        router.replace("/");
+      if (!auth.user || auth?.user?.role !== 'SUPER_ADMIN') {
+        router.replace("/"); 
       }
     }
-  }, [userRole, router, isMounted]);
+  }, [auth?.user, router, isMounted]);
 };
 
 export default useSuperAdminRoleGuard;

--- a/src/types/auth/index.ts
+++ b/src/types/auth/index.ts
@@ -24,6 +24,7 @@ export interface AuthState {
     id: string;
     name: string;
     username: string;
+    role: string;
   };
   loading: boolean;
 }
@@ -45,6 +46,7 @@ export interface AuthResponse {
     id: string;
     name: string;
     username: string;
+    role: string;
   };
 }
 


### PR DESCRIPTION
- Restrict access to admin pages for non-admin users
- Ensure authentication state is resolved before checking roles
- Redirect unauthorized users to the home page