### PR TITLE
feat(AppInfoSidebar): add category limit and 'Show All' to AppInfoSidebar

### DIFF
--- a/src/components/app/AppInfoSidebar.tsx
+++ b/src/components/app/AppInfoSidebar.tsx
@@ -108,11 +108,11 @@ function SidebarContent() {
         />
 
         <div className="mt-2 text-center">
-          <link
+          <Link
             href="/categories"
             className="text-blue-500 text-sm font-semibold hover:underline">
             عرض الكل
-          </link>
+          </Link>
         </div>
       </div>
   


### PR DESCRIPTION
## ✨ Changes
- Limited AppInfoSidebar to 5 categories + "Show All" button
- Prevented vertical overflow

## ✅ Done
- [x] No scrollbar appears
- [x] "Show All" works correctly

CLOSES #136