### PR TITLE
fix(auth): send email to backend for Google OAuth signups

### DIFF
--- a/src/components/OnlyApp/Comment/CommentItem.tsx
+++ b/src/components/OnlyApp/Comment/CommentItem.tsx
@@ -11,7 +11,7 @@ import RESPONSE_MESSAGES from "@/utils/constants/RESPONSE_MESSAGES";
 import ConfirmModal from "@/components/Modal/ConfirmModal";
 import MarkdownRenderer from '@/components/OnlyApp/MarkdownRenderer';
 import { voteComment } from "@/services/thread/voteService";
-import { CreateCommentPayload, FormattedVote, UserRole, Department, ThreadAuthor } from "@/types";
+import { CreateCommentPayload, FormattedVote, ThreadAuthor } from "@/types";
 import AuthorRoleBadge from "../Badge/AuthorRoleBadge";
 
 export interface CommentItemProps {

--- a/src/components/OnlyApp/ThreadListing/ThreadItemMinimal.tsx
+++ b/src/components/OnlyApp/ThreadListing/ThreadItemMinimal.tsx
@@ -1,4 +1,4 @@
-import { MessageSquare, Trash2 } from "lucide-react";
+import { MessageSquare } from "lucide-react";
 import Link from "next/link";
 import { ThreadMinimal } from "@/types";
 import UserInfo from "../UserInfo";

--- a/src/components/OnlyApp/UserInfo.tsx
+++ b/src/components/OnlyApp/UserInfo.tsx
@@ -18,7 +18,6 @@ function UserInfo({
   name,
   role,
   photoPath,
-  photoAlt,
   date,
   children,
   hideDetailsOnSmallScreens = false,
@@ -26,7 +25,7 @@ function UserInfo({
   isDeleted = false,
 }: UserInfoProps) {
   const isSmall = size === "sm";
-  const displayName = isDeleted ? "مستخدم محذوف" : name || photoAlt || '';
+  const displayName = isDeleted || !name ? "مستخدم محذوف" : getDisplayName(name);
   const displayPhotoPath = isDeleted ? undefined : photoPath;
 
   return (

--- a/src/services/auth/signupService.tsx
+++ b/src/services/auth/signupService.tsx
@@ -13,6 +13,9 @@ async function signupService(data: SignupFormData): Promise<AuthResult> {
       ...((!data.authMethod || data.authMethod === AuthMethod.EMAIL_PASSWORD) && { 
         password: data.password 
       }),
+      ...((data.authMethod === AuthMethod.OAUTH_GOOGLE) && {
+        email: data.email
+      }),
       name: data.name.trim(),
       authMethod: data.authMethod,
       academicNumber: data.academicNumber,


### PR DESCRIPTION
- Ensure the email field is included in the signup payload only for OAUTH_GOOGLE authentication.

CLOSES #247 